### PR TITLE
modify deployment for asserts dev environment

### DIFF
--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -3,7 +3,7 @@
 image:
   repo: asserts
   version: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 # Alternative payment gateway URL
 # Default is https://www.paypal.com
@@ -27,6 +27,6 @@ openshift: false
 
 # Storage class to use with redis statefulset.
 redis:
-  storageClassName: standard
+  storageClassName: gp3
 
 ocCreateRoute: false

--- a/K8s/ingress/ingress.yaml
+++ b/K8s/ingress/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: localhost
+    - host: robot-shop.dev.asserts.ai
       http:
         paths:
           - path: /api/catalogue/(.*)
@@ -59,3 +59,6 @@ spec:
                 name: web
                 port:
                   number: 8080
+  tls:
+    - hosts:
+        - robot-shop.dev.asserts.ai

--- a/K8s/install-all.sh
+++ b/K8s/install-all.sh
@@ -12,6 +12,7 @@ helm install percona-mongodb prometheus-community/prometheus-mongodb-exporter -f
 
 kubectl apply -f mongodb/mongodb-exporter-servicemonitor.yaml
 
-helm install ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx -f ingress/values.yaml -n robot-shop
+# commented out since we already have an ingress controller running
+#helm install ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx -f ingress/values.yaml -n robot-shop
 
 kubectl apply -f ingress/ingress.yaml -n robot-shop


### PR DESCRIPTION
Some changes to make the deployment work well in the asserts dev environment. Few things to note:

* ratings and shipping typically will error out until the other services are all running
* we already have multiple ingress controllers, you can easily hit the api by going to https://robot-shop.dev.asserts.ai
  * various paths shown in `K8s/ingress/ingress.yaml` (e.g. https://robot-shop.dev.asserts.ai/api/catalogue/metrics)
  * You can also look at the targets in https://prometheus.dev.asserts.ai for various paths being scraped
* Pull policy in `K8s/helm/values.yaml` changes to `IfNotPresent`. When always, throttling can occur during crashlooping. We can add authentication to this chart when solidified. If you want to deploy a new image, redeploy with `Always` if you need to. Just wanted to temporarily prevent throttling.