### PR TITLE
Use elastic search as storage for Jaeger

### DIFF
--- a/K8s/helm/templates/elasticsearch-service.yaml
+++ b/K8s/helm/templates/elasticsearch-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: es-jaeger
+    app: robot-shop
+    type: infra
+  name: es-jaeger
+  namespace: monitoring
+spec:
+  ports:
+    - name: es-jager-port
+      port: 9200
+      targetPort: 9200
+    - name: es-jaeger-add
+      port: 9300
+      targetPort: 9300
+  selector:
+    service: es-jaeger

--- a/K8s/helm/templates/elasticsearch-statefulset.yaml
+++ b/K8s/helm/templates/elasticsearch-statefulset.yaml
@@ -15,7 +15,6 @@ spec:
   serviceName: es-jaeger
   template:
     metadata:
-      creationTimestamp: null
       labels:
         service : es-jaeger
     spec:

--- a/K8s/helm/templates/elasticsearch-statefulset.yaml
+++ b/K8s/helm/templates/elasticsearch-statefulset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service : es-jaeger
+  name: es-jaeger
+  namespace: monitoring
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      service : es-jaeger
+  serviceName: es-jaeger
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        service : es-jaeger
+    spec:
+      containers:
+        - env:
+            - name: cluster.name
+              value: es-cluster
+            - name: discovery.type
+              value: single-node
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: bootstrap.memory_lock
+              value: "false"
+          image: elasticsearch:7.17.8
+          imagePullPolicy: IfNotPresent
+          name: es-jaeger
+          ports:
+            - containerPort: 9200
+              name: http
+              protocol: TCP
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: 150m
+              memory: 512Mi
+          securityContext:
+            privileged: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /usr/share/elasticsearch/data
+              name: elasticsearch-data
+  volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{ if not .Values.openshift }}
+        storageClassName: {{ .Values.redis.storageClassName }}
+        volumeMode: Filesystem
+        {{ end }}
+        resources:
+          requests:
+            storage: 10Gi

--- a/K8s/helm/templates/esindex-cleaner-cron.yaml
+++ b/K8s/helm/templates/esindex-cleaner-cron.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: esindexcleaner
-              image: jaegertracing/jaeger-es-index-cleaner:latest
+              image: jaegertracing/jaeger-es-index-cleaner:1.38
               imagePullPolicy: IfNotPresent
               args: ["3","http://es-jaeger:9200"]
           restartPolicy: OnFailure

--- a/K8s/helm/templates/esindex-cleaner-cron.yaml
+++ b/K8s/helm/templates/esindex-cleaner-cron.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: esindexcleaner
+  namespace: monitoring
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: esindexcleaner
+              image: jaegertracing/jaeger-es-index-cleaner:latest
+              imagePullPolicy: IfNotPresent
+              args: ["3","http://es-jaeger:9200"]
+          restartPolicy: OnFailure

--- a/K8s/helm/templates/jaeger-deployment.yaml
+++ b/K8s/helm/templates/jaeger-deployment.yaml
@@ -26,8 +26,10 @@ spec:
           image: jaegertracing/all-in-one:1.38
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: MEMORY_MAX_TRACES
-              value: "100000"
+            - name: SPAN_STORAGE_TYPE
+              value: "elasticsearch"
+            - name: ES_SERVER_URLS
+              value: "http://es-jaeger:9200"
           ports:
             - containerPort: 16686
             - containerPort: 5778

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,10 +33,40 @@ services:
     environment:
       COLLECTOR_ZIPKIN_HOST_PORT: 9411
       COLLECTOR_OTLP_ENABLED: "true"
+      SPAN_STORAGE_TYPE: "elasticsearch"
+      ES_SERVER_URLS: "http://host.docker.internal:9200"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - type: bind
         source: ./jaeger-sampling.json
         target: /etc/jaeger/sampling_strategies.json
+    logging:
+      <<: *logging
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.8
+    container_name: elasticsearch
+    networks:
+      - robot-shop
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://host.docker.internal:9200" ]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    environment:
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - 9200:9200
+      - 9300:9300
     logging:
       <<: *logging
   rabbitmq:


### PR DESCRIPTION
Adding stateful set for elastic search service that will be used in jaeger service as a storage type.
For elastic search the memory is set to 10G to start with, incase required we can increase.
To clean the old trace, spans there is jaeger-es-index-cleaner which is setup as a cron job, the single run just cleans once so we need to run every day. It is schedule to run ever day start. Traces that are older than 3 days are cleared for now.
[ch14462]