### PR TITLE
Fix elastic search dir permission

### DIFF
--- a/K8s/helm/templates/elasticsearch-statefulset.yaml
+++ b/K8s/helm/templates/elasticsearch-statefulset.yaml
@@ -62,3 +62,16 @@ spec:
         resources:
           requests:
             storage: 10Gi
+  extraInitContainers:
+    - name: create
+      image: busybox:1.28
+      command: ['mkdir', '/usr/share/elasticsearch/data/nodes/']
+      volumeMounts:
+      - mountPath: /usr/share/elasticsearch/data
+        name: elasticsearch-data
+    - name: file-permissions
+      image: busybox:1.28
+      command: ['chown', '-R', '1000:1000', '/usr/share/elasticsearch/']
+      volumeMounts:
+      - mountPath: /usr/share/elasticsearch/data
+        name: elasticsearch-data


### PR DESCRIPTION
Adding permission for elastic search for the data directly while init of container.
[ch14462]