### PR TITLE
setting trace for request to 1

### DIFF
--- a/K8s/helm/templates/otel-collector-config.yaml
+++ b/K8s/helm/templates/otel-collector-config.yaml
@@ -28,6 +28,7 @@ data:
           password: {{ .Values.otelcollector.assertsPassword }}
         asserts_env: {{ .Values.otelcollector.assertsEnv }}
         asserts_site: {{ .Values.otelcollector.assertsSite }}
+        trace_rate_limit_per_service_per_request: {{ .Values.otelcollector.tracesPerRequest }}
         span_attribute_match_regex:
           "rpc.system": "aws-api"
           "rpc.service": "(Sqs)|(DynamoDb)"

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -57,4 +57,4 @@ otelcollector:
   assertsServer: https://chief.app.dev.asserts.ai/api-server
   assertsEnv: dev
   assertsSite: dev
-
+  tracesPerRequest: 1

--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -21,6 +21,7 @@ processors:
       endpoint: https://chief.app.dev.asserts.ai/api-server
     asserts_env: dev
     asserts_site: dev
+    trace_rate_limit_per_service_per_request: 1
     span_attribute_match_regex:
       "rpc.system": "aws-api"
       "rpc.service": "(Sqs)|(DynamoDb)"


### PR DESCRIPTION
setting traces for each request each service to 1 instead of 3 which is default.
[ch15123]